### PR TITLE
Fix/android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ lcov.info
 link/
 link.tar.gz
 .vscode
+lib/api/third_party/wamr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hc-wasmer"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-cache"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "blake3",
  "clap",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-compiler"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-compiler-cranelift"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-compiler-llvm"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "byteorder",
  "cc",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-compiler-singlepass"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-derive"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "compiletest_rs",
  "hc-wasmer-types",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-middlewares"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "hc-wasmer",
  "hc-wasmer-types",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-object"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "hc-wasmer-types",
  "object 0.29.0",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-types"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "hc-wasmer-vm"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "4.3.6-hc.0"
+version = "4.3.6-hc.1"
 dependencies = [
  "anyhow",
  "build-deps",

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -69,6 +69,7 @@ fn main() {
         let wamr_platform_dir = wamr_dir.join("product-mini/platforms").join(target_os);
         let dst = Config::new(wamr_platform_dir.as_path())
             .always_configure(true)
+            .configure_arg("--fresh")
             .generator("Unix Makefiles")
             .no_build_target(true)
             .define(

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -68,6 +68,16 @@ fn main() {
             .define("WAMR_BUILD_SHARED_MEMORY", "1")
             .define("WAMR_BUILD_MULTI_MODULE", "0")
             .define("WAMR_DISABLE_HW_BOUND_CHECK", "1")
+            #[cfg(target_os = "linux")]
+            .define("WAMR_BUILD_PLATFORM", "linux")
+            #[cfg(target_os = "android")]
+            .define("WAMR_BUILD_PLATFORM", "android")
+            #[cfg(target_os = "windows")]
+            .define("WAMR_BUILD_PLATFORM", "windows")
+            #[cfg(target_os = "darwin")]
+            .define("WAMR_BUILD_PLATFORM", "darwin")
+            #[cfg(target_os = "freebsd")]
+            .define("WAMR_BUILD_PLATFORM", "freebsd")
             .build();
 
         // Check output of `cargo build --verbose`, should see something like:

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -41,7 +41,8 @@ fn main() {
         }
         */
 
-        let dst = Config::new(wamr_dir.clone())
+        let mut dst_config = Config::new(wamr_dir.as_path());
+        dst_config
             .always_configure(true)
             .generator("Unix Makefiles")
             .define(
@@ -67,18 +68,21 @@ fn main() {
             .define("WAMR_BUILD_LIBC_BUILTIN", "0")
             .define("WAMR_BUILD_SHARED_MEMORY", "1")
             .define("WAMR_BUILD_MULTI_MODULE", "0")
-            .define("WAMR_DISABLE_HW_BOUND_CHECK", "1")
-            #[cfg(target_os = "linux")]
-            .define("WAMR_BUILD_PLATFORM", "linux")
-            #[cfg(target_os = "android")]
-            .define("WAMR_BUILD_PLATFORM", "android")
-            #[cfg(target_os = "windows")]
-            .define("WAMR_BUILD_PLATFORM", "windows")
-            #[cfg(target_os = "darwin")]
-            .define("WAMR_BUILD_PLATFORM", "darwin")
-            #[cfg(target_os = "freebsd")]
-            .define("WAMR_BUILD_PLATFORM", "freebsd")
-            .build();
+            .define("WAMR_DISABLE_HW_BOUND_CHECK", "1");
+        
+        // Set WAMR_BUILD_PLATFORM to the cargo target
+        if cfg!(target_os = "linux") {
+            dst_config.define("WAMR_BUILD_PLATFORM", "linux");
+        } else if cfg!(target_os = "windows") {
+            dst_config.define("WAMR_BUILD_PLATFORM", "windows");
+        } else if cfg!(target_os = "darwin") {
+            dst_config.define("WAMR_BUILD_PLATFORM", "darwin");
+        } else if cfg!(target_os = "android") {
+            dst_config.define("WAMR_BUILD_PLATFORM", "android");
+        } else if cfg!(target_os = "freebsd") {
+            dst_config.define("WAMR_BUILD_PLATFORM", "freebsd");
+        }
+        let dst = dst_config.build();
 
         // Check output of `cargo build --verbose`, should see something like:
         // -L native=/path/runng/target/debug/build/runng-sys-abc1234/out

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -69,7 +69,6 @@ fn main() {
         let wamr_platform_dir = wamr_dir.join("product-mini/platforms").join(target_os);
         let dst = Config::new(wamr_platform_dir.as_path())
             .always_configure(true)
-            .configure_arg("--fresh")
             .generator("Unix Makefiles")
             .no_build_target(true)
             .define(

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -8,6 +8,7 @@ fn main() {
         use std::{env, path::PathBuf};
 
         let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let wamr_dir = PathBuf::from(&crate_root).join("third_party/wamr");
 
         let zip = ureq::get(WAMR_ZIP).call().expect("failed to download wamr");
@@ -43,18 +44,10 @@ fn main() {
 
         let mut wamr_platform_dir = wamr_dir.join("product-mini/platforms");
 
-        if cfg!(target_os = "linux") {
+        if target_os == "linux" || target_os == "windows" || target_os =="darwin" || target_os == "android" || target_os == "freebsd" {
             wamr_platform_dir = wamr_platform_dir.join("linux");
-        } else if cfg!(target_os = "windows") {
-            wamr_platform_dir = wamr_platform_dir.join("windows");
-        } else if cfg!(target_os = "darwin") {
-            wamr_platform_dir = wamr_platform_dir.join("darwin");
-        } else if cfg!(target_os = "android") {
-            wamr_platform_dir = wamr_platform_dir.join("android");
-        } else if cfg!(target_os = "freebsd") {
-            wamr_platform_dir = wamr_platform_dir.join("freebsd");
         } else {
-            // compile_error!("Supported target_os are linux, windows, android, freebsd");
+            compile_error!("Supported target_os are linux, windows, android, freebsd");
         }
 
         let mut dst_config = Config::new(wamr_platform_dir.as_path());
@@ -87,16 +80,10 @@ fn main() {
             .define("WAMR_DISABLE_HW_BOUND_CHECK", "1");
         
         // Set WAMR_BUILD_PLATFORM to the cargo target
-        // if cfg!(target_os = "linux") {
-        //     dst_config.define("WAMR_BUILD_PLATFORM", "linux");
-        // } else if cfg!(target_os = "windows") {
-        //     dst_config.define("WAMR_BUILD_PLATFORM", "windows");
-        // } else if cfg!(target_os = "darwin") {
-        //     dst_config.define("WAMR_BUILD_PLATFORM", "darwin");
-        // } else if cfg!(target_os = "android") {
-        //     dst_config.define("WAMR_BUILD_PLATFORM", "android");
-        // } else if cfg!(target_os = "freebsd") {
-        //     dst_config.define("WAMR_BUILD_PLATFORM", "freebsd");
+        // if target_os == "linux" || target_os == "windows" || target_os =="darwin" || target_os == "android" || target_os == "freebsd" {
+        //     dst_config.define("WAMR_BUILD_PLATFORM", target_os);
+        // } else {
+        //     compile_error!("Supported target_os are linux, windows, android, freebsd");
         // }
         let dst = dst_config.build();
 

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -8,7 +8,7 @@ fn main() {
         use std::{env, path::PathBuf};
 
         let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
-        let wamr_dir = PathBuf::from(&crate_root).join("third_party").join("wamr");
+        let wamr_dir = PathBuf::from(&crate_root).join("third_party/wamr");
 
         let zip = ureq::get(WAMR_ZIP).call().expect("failed to download wamr");
 
@@ -41,7 +41,23 @@ fn main() {
         }
         */
 
-        let mut dst_config = Config::new(wamr_dir.as_path());
+        let mut wamr_platform_dir = wamr_dir.join("product-mini-platforms");
+
+        if cfg!(target_os = "linux") {
+            wamr_platform_dir = wamr_platform_dir.join("linux");
+        } else if cfg!(target_os = "windows") {
+            wamr_platform_dir = wamr_platform_dir.join("windows");
+        } else if cfg!(target_os = "darwin") {
+            wamr_platform_dir = wamr_platform_dir.join("darwin");
+        } else if cfg!(target_os = "android") {
+            wamr_platform_dir = wamr_platform_dir.join("android");
+        } else if cfg!(target_os = "freebsd") {
+            wamr_platform_dir = wamr_platform_dir.join("freebsd");
+        } else {
+            // compile_error!("Supported target_os are linux, windows, android, freebsd");
+        }
+
+        let mut dst_config = Config::new(wamr_platform_dir.as_path());
         dst_config
             .always_configure(true)
             .generator("Unix Makefiles")
@@ -61,7 +77,7 @@ fn main() {
             .define("WAMR_BUILD_BULK_MEMORY", "1")
             .define("WAMR_BUILD_REF_TYPES", "1")
             .define("WAMR_BUILD_SIMD", "1")
-            .define("WAMR_ENABLE_FAST_INTERP", "1")
+            .define("WAMR_BUILD_FAST_INTERP", "1")
             .define("WAMR_BUILD_LIB_PTHREAD", "1")
             .define("WAMR_BUILD_LIB_WASI_THREADS", "0")
             .define("WAMR_BUILD_LIBC_WASI", "0")
@@ -71,17 +87,17 @@ fn main() {
             .define("WAMR_DISABLE_HW_BOUND_CHECK", "1");
         
         // Set WAMR_BUILD_PLATFORM to the cargo target
-        if cfg!(target_os = "linux") {
-            dst_config.define("WAMR_BUILD_PLATFORM", "linux");
-        } else if cfg!(target_os = "windows") {
-            dst_config.define("WAMR_BUILD_PLATFORM", "windows");
-        } else if cfg!(target_os = "darwin") {
-            dst_config.define("WAMR_BUILD_PLATFORM", "darwin");
-        } else if cfg!(target_os = "android") {
-            dst_config.define("WAMR_BUILD_PLATFORM", "android");
-        } else if cfg!(target_os = "freebsd") {
-            dst_config.define("WAMR_BUILD_PLATFORM", "freebsd");
-        }
+        // if cfg!(target_os = "linux") {
+        //     dst_config.define("WAMR_BUILD_PLATFORM", "linux");
+        // } else if cfg!(target_os = "windows") {
+        //     dst_config.define("WAMR_BUILD_PLATFORM", "windows");
+        // } else if cfg!(target_os = "darwin") {
+        //     dst_config.define("WAMR_BUILD_PLATFORM", "darwin");
+        // } else if cfg!(target_os = "android") {
+        //     dst_config.define("WAMR_BUILD_PLATFORM", "android");
+        // } else if cfg!(target_os = "freebsd") {
+        //     dst_config.define("WAMR_BUILD_PLATFORM", "freebsd");
+        // }
         let dst = dst_config.build();
 
         // Check output of `cargo build --verbose`, should see something like:

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -41,7 +41,7 @@ fn main() {
         }
         */
 
-        let mut wamr_platform_dir = wamr_dir.join("product-mini-platforms");
+        let mut wamr_platform_dir = wamr_dir.join("product-mini/platforms");
 
         if cfg!(target_os = "linux") {
             wamr_platform_dir = wamr_platform_dir.join("linux");


### PR DESCRIPTION
Use platform-specific CMakeLists.txt used for building iwasm binary. Building iwasm also builds the libraries we are linking to and it appears to be the only method supported for building on all the platforms.

I'm still having an inconsistent issue where cmake complains that WAMR_BUILD_TARGET is not set -- seems to happen every other run. I'm guessing there is some cmake cache from the prior run that is not getting cleared properly.

With this setup, and some changes to the nix environment, android builds are working.

I'm guessing this will make win32 builds work as well, but need to test.

It sounds like this work may get merged into wasmer's 5.x release, so perhaps we can wait for that.